### PR TITLE
[deployment-docker]Adds functionality to publish UBI-based images to GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             - setup_environment
             - checkout
             - run: export GOOGLE_APPLICATION_CREDENTIALS=dockerconfig.json
-            - run: echo "${GCLOUD_SERVICE_ACCOUNT_INTERNAL}" | base64 -d >${GOOGLE_APPLICATION_CREDENTIALS}
+            - run: echo "${GCLOUD_SERVICE_ACCOUNT_INTERNAL}" | base64 -d >"${GOOGLE_APPLICATION_CREDENTIALS}"
             - run: cat $GOOGLE_APPLICATION_CREDENTIALS | docker login -u _json_key --password-stdin https://gcr.io
             - run: make build-node redhat-verify-ubi-gcr-internal-node VARIANT=redhat
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,8 @@ jobs:
         steps:
             - setup_environment
             - checkout
-            - run: exit 0
-            # - run: make test
-            # - run: make test-destroy
+            - run: make test
+            - run: make test-destroy
 
     redhat:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,9 @@ jobs:
         steps:
             - setup_environment
             - checkout
-            - run: make test
-            - run: make test-destroy
+            - run: exit 0
+            # - run: make test
+            # - run: make test-destroy
 
     redhat:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,10 @@ jobs:
         steps:
             - setup_environment
             - checkout
-            - run: export GOOGLE_APPLICATION_CREDENTIALS=./dockerconfig.json
-            - run: touch ${GOOGLE_APPLICATION_CREDENTIALS}
-            - run: echo "${GCLOUD_SERVICE_ACCOUNT_INTERNAL}" | base64 -d >"${GOOGLE_APPLICATION_CREDENTIALS}"
-            - run: cat "${GOOGLE_APPLICATION_CREDENTIALS}" | docker login -u _json_key --password-stdin https://gcr.io
+            # We can't use Bash variables in CircleCI so we just duplicate the ""./dockerconfig.json"
+            # string here.
+            - run: echo "${GCLOUD_SERVICE_ACCOUNT_INTERNAL}" | base64 -d >./dockerconfig.json
+            - run: cat ./dockerconfig.json | docker login -u _json_key --password-stdin https://gcr.io
             - run: make build-node redhat-verify-ubi-gcr-internal-node VARIANT=redhat
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,28 @@ jobs:
             - run: docker login -u ${DOCKER_HUB_USER} --password ${DOCKER_HUB_KEY}
             - run: make build-<<parameters.package>> publish-<<parameters.package>>
 
+    ubi-gcr-internal:
+        parameters:
+            package:
+                type: string
+        machine:
+            # https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/
+            image: ubuntu-2004:202201-02
+        steps:
+            - setup_environment
+            - checkout
+            - run: export GOOGLE_APPLICATION_CREDENTIALS=dockerconfig.json
+            - run: echo $GCLOUD_SERVICE_ACCOUNT_INTERNAL | base64 -d >${GOOGLE_APPLICATION_CREDENTIALS}
+            - run: cat $GOOGLE_APPLICATION_CREDENTIALS | docker login -u _json_key --password-stdin https://gcr.io
+            - run: make build-node redhat-verify-ubi-gcr-internal-node VARIANT=redhat
+
 workflows:
     test_publish:
         jobs:
             - test
+
+            - publish-gcr-internal:
+                  name: publish-gcr-internal-<< matrix.package >>
 
             - publish-dockerhub:
                   name: publish-dockerhub-<< matrix.package >>
@@ -144,3 +162,14 @@ workflows:
                   name: redhat-ciab
                   requires:
                       - publish-redhat-ciab
+
+            - publish-ubi-gcr-internal:
+                  name: publish-ubi-gcr-internal
+                  type: approval
+                  requires:
+                      - test
+
+            - ubi-gcr-internal:
+                  name: ubi-gcr-internal
+                  requires:
+                      - publish-ubi-gcr-internal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,7 @@ jobs:
             - run: make build-<<parameters.package>> publish-<<parameters.package>>
 
     ubi-gcr-internal:
-        parameters:
-            package:
-                type: string
-        machine:
-            # https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/
-            image: ubuntu-2004:202201-02
+        machine: true
         steps:
             - setup_environment
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,9 +66,6 @@ workflows:
         jobs:
             - test
 
-            - publish-gcr-internal:
-                  name: publish-gcr-internal-<< matrix.package >>
-
             - publish-dockerhub:
                   name: publish-dockerhub-<< matrix.package >>
                   type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             - setup_environment
             - checkout
             - run: export GOOGLE_APPLICATION_CREDENTIALS=dockerconfig.json
-            - run: echo $GCLOUD_SERVICE_ACCOUNT_INTERNAL | base64 -d >${GOOGLE_APPLICATION_CREDENTIALS}
+            - run: echo "${GCLOUD_SERVICE_ACCOUNT_INTERNAL}" | base64 -d >${GOOGLE_APPLICATION_CREDENTIALS}
             - run: cat $GOOGLE_APPLICATION_CREDENTIALS | docker login -u _json_key --password-stdin https://gcr.io
             - run: make build-node redhat-verify-ubi-gcr-internal-node VARIANT=redhat
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,10 @@ jobs:
         steps:
             - setup_environment
             - checkout
-            - run: export GOOGLE_APPLICATION_CREDENTIALS=dockerconfig.json
+            - run: export GOOGLE_APPLICATION_CREDENTIALS=./dockerconfig.json
+            - run: touch ${GOOGLE_APPLICATION_CREDENTIALS}
             - run: echo "${GCLOUD_SERVICE_ACCOUNT_INTERNAL}" | base64 -d >"${GOOGLE_APPLICATION_CREDENTIALS}"
-            - run: cat $GOOGLE_APPLICATION_CREDENTIALS | docker login -u _json_key --password-stdin https://gcr.io
+            - run: cat "${GOOGLE_APPLICATION_CREDENTIALS}" | docker login -u _json_key --password-stdin https://gcr.io
             - run: make build-node redhat-verify-ubi-gcr-internal-node VARIANT=redhat
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,13 @@ redhat-verify-ciab:
 	docker push scan.connect.redhat.com/ospid-6b69e5e1-d98a-4d75-a591-e300d4820ecb/cluster-in-a-box:${CIAB_TAG}
 	@echo "View results + publish: https://connect.redhat.com/project/923891/view"
 
+# This is used to publish an UBI-based (known as redhat) node image to GCR.io.
+.PHONY: redhat-verify-ubi-gcr-internal-node
+redhat-verify-ubi-gcr-internal-node:
+	docker tag singlestore/node:${NODE_TAG} gcr.io/internal-freya/memsql/node:${NODE_TAG}
+	docker push gcr.io/internal-freya/memsql/node:${NODE_TAG}
+	@echo "View results + publish: https://console.cloud.google.com/gcr/images/internal-freya/global/memsql/node"
+
 .PHONY: test-destroy
 test-destroy:
 	@-docker rm -f memsql-node-ma memsql-node-leaf memsql-ciab


### PR DESCRIPTION
This diff adds the possibility to push a UBI-based node image to GCR. This only works for the latest production node image, similarly to how our RedHat Registry publishing works.

Here's an example push:
https://app.circleci.com/pipelines/github/memsql/deployment-docker/408/workflows/cb44df38-663f-42be-9e8c-f93c0f77639a/jobs/1229