### PR TITLE
[deployment-docker] Migrate from 'gcr.io/internal-freya' to 'gcr.io/singlestore-public'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             - checkout
             # We can't use Bash variables in CircleCI so we just duplicate the ""./dockerconfig.json"
             # string here.
-            - run: echo "${GCLOUD_SERVICE_ACCOUNT_INTERNAL}" | base64 -d >./dockerconfig.json
+            - run: echo "${GCLOUD_SERVICE_ACCOUNT_SINGLESTORE_PUBLIC}" | base64 -d >./dockerconfig.json
             - run: cat ./dockerconfig.json | docker login -u _json_key --password-stdin https://gcr.io
             - run: make build-node redhat-verify-ubi-gcr-internal-node VARIANT=redhat
 

--- a/Makefile
+++ b/Makefile
@@ -407,9 +407,9 @@ redhat-verify-ciab:
 # This is used to publish an UBI-based (known as redhat) node image to GCR.io.
 .PHONY: redhat-verify-ubi-gcr-internal-node
 redhat-verify-ubi-gcr-internal-node:
-	docker tag singlestore/node:${NODE_TAG} gcr.io/internal-freya/memsql/node:${NODE_TAG}
-	docker push gcr.io/internal-freya/memsql/node:${NODE_TAG}
-	@echo "View results + publish: https://console.cloud.google.com/gcr/images/internal-freya/global/memsql/node"
+	docker tag singlestore/node:${NODE_TAG} gcr.io/singlestore-public/memsql/node:${NODE_TAG}
+	docker push gcr.io/singlestore-public/memsql/node:${NODE_TAG}
+	@echo "View results + publish: https://console.cloud.google.com/gcr/images/singlestore-public/global/memsql/node"
 
 .PHONY: test-destroy
 test-destroy:


### PR DESCRIPTION
This PR adapts what was introduced in https://github.com/memsql/deployment-docker/pull/8 in order to use `gcr.io/singlestore-public` repository, instead of `gcr.io/internal-freya`.

Here's an example push:
https://app.circleci.com/pipelines/github/memsql/deployment-docker/425/workflows/60e515f5-334f-457c-bf5f-3541e32ccc51/jobs/1279