### PR TITLE
chore(base): use package-manager to install jq; to allow local-dev to…

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -31,15 +31,5 @@ RUN dnf --enablerepo=* clean all && dnf update -y; exit 0
 RUN yum update expat libxml2 gnupg2 libgcrypt openssl-libs pcre2 curl libcurl-minimal systemd platform-python python3-libs gnutls libksba sqlite-libs zlib libcom_err krb5-libs dbus libtasn1 -y
 RUN yum remove vim-minimal platform-python-pip.noarch -y
 
-# jq 1.6
-ENV JQ_VERSION='1.6'
-RUN wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/jq-release.key -O /tmp/jq-release.key && \
-    wget --no-check-certificate https://raw.githubusercontent.com/stedolan/jq/master/sig/v${JQ_VERSION}/jq-linux64.asc -O /tmp/jq-linux64.asc && \
-    wget --no-check-certificate https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /tmp/jq-linux64 && \
-    gpg --import /tmp/jq-release.key && \
-    gpg --verify /tmp/jq-linux64.asc /tmp/jq-linux64 && \
-    cp /tmp/jq-linux64 /usr/bin/jq && \
-    chmod +x /usr/bin/jq && \
-    rm -f /tmp/jq-release.key && \
-    rm -f /tmp/jq-linux64.asc && \
-    rm -f /tmp/jq-linux64
+# install jq
+RUN yum install jq -y


### PR DESCRIPTION
… be built

Currently when building the local-dev for the psyduck on debian 11, the base image times out waiting to connect to github to download the package, not exactly sure why the networking wouldn't work but using the package manager seems to make it work nicely.