### PR TITLE
[deployment-docker] Adds Make target to publish-gcr-node-preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -477,6 +477,11 @@ publish-gcr-node-8-1:
 	docker tag memsql/node:${NODE_TAG_8_1} gcr.io/singlestore-public/mirror/docker.io/memsql/node:${NODE_TAG_8_1}
 	docker push gcr.io/singlestore-public/mirror/docker.io/memsql/node:${NODE_TAG_8_1}
 
+.PHONY: publish-gcr-node-preview
+publish-gcr-node-preview:
+	docker tag memsql/node:${NODE_TAG_PREVIEW} gcr.io/singlestore-public/mirror/docker.io/memsql/node:${NODE_TAG_PREVIEW}
+	docker push gcr.io/singlestore-public/mirror/docker.io/memsql/node:${NODE_TAG_PREVIEW}
+
 .PHONY: build-dynamic-node
 build-dynamic-node: build-base
 	docker build \


### PR DESCRIPTION
This diff adds a missing Make target which is required for pushing preview node images to GCR.

Here's an example CI job where this was missing: https://app.circleci.com/pipelines/github/memsql/deployment-docker/685/workflows/3ee49ee3-f668-4832-acd0-7ae79c03f380/jobs/4359.