### PR TITLE
Fixing cluster-in-a-box target

### DIFF
--- a/Dockerfile-ciab
+++ b/Dockerfile-ciab
@@ -9,7 +9,7 @@ ARG STUDIO_VERSION
 ARG TOOLBOX_VERSION
 RUN yum install -y \
     singlestore-client-${CLIENT_VERSION} \
-    singlestoredb-server${SERVER_VERSION} \
+    memsql-server${SERVER_VERSION} \
     singlestoredb-studio-${STUDIO_VERSION} \
     singlestoredb-toolbox-${TOOLBOX_VERSION} \
  && yum clean all


### PR DESCRIPTION
`make build-ciab-dev` was failing during `yum install -y singlestoredb-server${SERVER_VERSION}`. The change to use `singlestoredb-server` and not `memsql-server` was a part of branding updates, but it doesn't work. For that reason, reverting back to `memsql-server`.

```
 => ERROR [2/7] RUN yum install -y     singlestore-client-1.0.5     singlestoredb-server8.7.1-03d4661e4f     singlestoredb-st  4.1s
------                                                                                                                              
 > [2/7] RUN yum install -y     singlestore-client-1.0.5     singlestoredb-server8.7.1-03d4661e4f     singlestoredb-studio-4.0.17     singlestoredb-toolbox-1.17.8  && yum clean all:                                                                                   
1.978 AlmaLinux 8 - BaseOS                            6.3 kB/s | 3.8 kB     00:00                                                   
2.254 AlmaLinux 8 - AppStream                          21 kB/s | 4.1 kB     00:00                                                   
2.573 AlmaLinux 8 - Extras                             18 kB/s | 3.8 kB     00:00                                                   
2.824 MemSQL                                          2.5 kB/s | 606  B     00:00    
3.387 MemSQL                                          304 kB/s | 170 kB     00:00    
3.972 No match for argument: singlestoredb-server8.7.1-03d4661e4f
3.993 Error: Unable to find a match: singlestoredb-server8.7.1-03d4661e4f
------
Dockerfile-ciab:10
--------------------
   9 |     ARG TOOLBOX_VERSION
  10 | >>> RUN yum install -y \
  11 | >>>     singlestore-client-${CLIENT_VERSION} \
  12 | >>>     singlestoredb-server${SERVER_VERSION} \
  13 | >>>     singlestoredb-studio-${STUDIO_VERSION} \
  14 | >>>     singlestoredb-toolbox-${TOOLBOX_VERSION} \
  15 | >>>  && yum clean all
  16 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c yum install -y     singlestore-client-${CLIENT_VERSION}     singlestoredb-server${SERVER_VERSION}     singlestoredb-studio-${STUDIO_VERSION}     singlestoredb-toolbox-${TOOLBOX_VERSION}  && yum clean all" did not complete successfully: exit code: 1
make: *** [build-ciab-dev] Error 1
```

Our internal docs were trying https://docs.google.com/document/d/1WRfcatOlwcCLYgsGC1P-JDIOm2mxHltuklW-k8gKY9k/edit and reached out to me with the error. Note that `cluster-in-a-box` is deprecated in favor of https://github.com/singlestore-labs/singlestoredb-dev-image. However, the dev image doesn't seem to satisfy the pre-release workflow, so fixing the current target.